### PR TITLE
Require omniauth-oauth2 to prevent load order problems

### DIFF
--- a/lib/omniauth-clearbit/version.rb
+++ b/lib/omniauth-clearbit/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Clearbit
-    VERSION = "1.1.2"
+    VERSION = "1.1.3"
   end
 end

--- a/lib/omniauth/strategies/clearbit.rb
+++ b/lib/omniauth/strategies/clearbit.rb
@@ -1,3 +1,5 @@
+require 'omniauth-oauth2'
+
 module OmniAuth
   module Strategies
     class Clearbit < OmniAuth::Strategies::OAuth2


### PR DESCRIPTION
We have found some issues when this gem is required before the omniauth-oauth2 gem and this is due to not requiring the dependency when it is used.